### PR TITLE
Stab/194 support add with groups

### DIFF
--- a/emma/model/member.py
+++ b/emma/model/member.py
@@ -134,12 +134,12 @@ class Member(BaseApiModel):
 
         return extracted
 
-    def _add(self, signup_form_id):
+    def _add(self, signup_form_id, group_ids):
         """Add a single member"""
         path = '/members/add'
         data = self.extract()
-        if len(self.groups):
-            data['group_ids'] = self.groups.keys()
+        if group_ids:
+            data['group_ids'] = group_ids
         if signup_form_id:
             data['signup_form_id'] = signup_form_id
 
@@ -158,7 +158,7 @@ class Member(BaseApiModel):
         if not self.account.adapter.put(path, data):
             raise ex.MemberUpdateError()
 
-    def save(self, signup_form_id=None):
+    def save(self, signup_form_id=None, group_ids=None):
         """
         Add or update this :class:`Member`
 
@@ -177,7 +177,7 @@ class Member(BaseApiModel):
             None
         """
         if 'member_id' not in self._dict:
-            return self._add(signup_form_id)
+            return self._add(signup_form_id, group_ids)
         else:
             return self._update()
 

--- a/tests/model/member_test.py
+++ b/tests/model/member_test.py
@@ -239,16 +239,13 @@ class MemberTest(unittest.TestCase):
                 'email':u"test@example.com",
                 'fields': {'first_name':u"Emma"}
             })
-        mbr.groups._dict = {
-            1025: mbr.groups.factory()
-        }
         MockAdapter.expected = {
             'status': u"a",
             'added': True,
             'member_id': 1024
         }
 
-        result = mbr.save()
+        result = mbr.save(group_ids=[1025])
 
         self.assertIsNone(result)
         self.assertEquals(mbr.account.adapter.called, 1)


### PR DESCRIPTION
This still needs more testing.

This is a change to allow someone to add a new member into groups in a single save, so that sign-up autoresponders will trigger consistently.
