### PR TITLE
Added fix in requests_adapter.py for get() method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
   - "2.7"
-install: "pip install -r requirements.txt --use-mirrors"
+install: "pip install -r requirements.txt"
 script: nosetests

--- a/emma/adapter/requests_adapter.py
+++ b/emma/adapter/requests_adapter.py
@@ -101,8 +101,8 @@ class RequestsAdapter(AbstractAdapter):
             >>> adptr.get('/members', {...})
             [{...}, {...}, ...] # 500-999
         """
-
-        params.update(self.pagination_add_ons())
+        if params:
+            params.update(self.pagination_add_ons())
 
         return process_response(
             requests.get(


### PR DESCRIPTION
Method now checks that params exists and is not None before proceeding. Previously method would raise AttributeError that NoneType object has not attribute 'update'. Error was seen using member.mailings.fetch_all() method.